### PR TITLE
KolonizationMonitor: Rebuild Rersource list after switching vessels

### DIFF
--- a/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
+++ b/Source/KolonyTools/KolonyTools/Kolonization/KolonizationMonitor.cs
@@ -626,11 +626,11 @@ namespace KolonyTools
             if (idx == NearVessels.Count)
                 idx = 0;
 
-            _resList = RebuildResourceList();
-
             v.Setup(NearVessels[idx], idx);
             if (_fromVessel.Idx == _toVessel.Idx && NearVessels.Count > 1)
                 SetNextVessel(v);
+
+            _resList = RebuildResourceList();
         }
         internal void OnDestroy()
         {


### PR DESCRIPTION
The resource list for the KolonizationMonitor was created before
switching the vessels. This caused the list to be incorrect.

Fixes #1100